### PR TITLE
return buildinfo default, and add params save_uploaded_info_json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Gemfile.lock
 fastlane/README.md
 fastlane/report.xml
 .vscode
+coverage
+pgyer-fastlane-uploaded-app-info.json

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Plan A: update all plguins (Recommended)
 
 
 ```bash
-fastlane update_plugins 
+fastlane update_plugins
 ```
 
 Plan B: update pgyer plugin only
@@ -71,6 +71,29 @@ lane :beta do
 end
 ```
 
+
+If the upload is successful, you will get information about the app after it is uploaded, which is returned from the API interface app/buildinfo . You can pass it to other plugins, or export it to the terminal for use by other scripts:
+
+```ruby
+lane :beta do
+  gym
+  answer = pgyer(api_key: "xxxxxx")
+  puts answer
+  # terminal outputs like this if uploaded successfully
+  # {"buildKey"=>"xxxx", "buildType"=>"2", "buildIsFirst"=>"0", "buildIsLastest"=>"1", "buildFileKey"=>"xxx.apk", "buildFileName"=>"", "buildFileSize"=>"111111", "buildName"=>"testApk", "buildVersion"=>"0.11.0", "buildVersionNo"=>"13", "buildBuildVersion"=>"10", "buildIdentifier"=>"com.pgyer.testapk", "buildIcon"=>"xxxx", "buildDescription"=>"", "buildUpdateDescription"=>"", "buildScreenshots"=>"", "buildShortcutUrl"=>"xxxxxxx", "buildCreated"=>"2023-04-04 11:33:24", "buildUpdated"=>"2023-04-04 11:33:24", "buildQRCodeURL"=>"https://www.pgyer.com/app/qrcodeHistory/xxxxxx", "fastlaneAddedWholeVisitUrl"=>"https://www.pgyer.com/xxxxxx"}
+  puts "url = #{answer["fastlaneAddedWholeVisitUrl"]}"
+
+  # terminal outputs like this if uploaded successfully
+  # url = https://www.pgyer.com/xxxxxx
+
+  # More information please visit https://www.pgyer.com/doc/view/api#fastUploadApp to check API "https://www.pgyer.com/apiv2/app/buildInfo"
+
+end
+```
+
+
+```
+
 And more params
 
 ```
@@ -88,6 +111,8 @@ install_start_date: The value is a string of characters, for example, 2018-01-01
 install_end_date: The value is a string of characters, such as 2018-12-31.
 
 channel: Need to update the specified channel of the download short link, can specify only one channel, string type, such as: ABCD. Specifies channel uploads. If you do not have one, do not use this parameter.
+
+save_uploaded_info_json: (true or false, default to false) Whether to save the information returned by the API interface to a json file.
 
 ```
 ## Run tests for this plugin

--- a/lib/fastlane/plugin/pgyer/version.rb
+++ b/lib/fastlane/plugin/pgyer/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Pgyer
-    VERSION = "0.2.4"
+    VERSION = "0.2.5"
   end
 end


### PR DESCRIPTION
将fastlane 命令的结果, 返回了 buildinfo 的数据, 供用户在后续脚本中自行使用

同时增加了参数 save_uploaded_info_json, 为 true 时, 将buildinfo结果存储在了 当前目录下的 pgyer-fastlane-uploaded-app-info.json 中, 参数默认为false 